### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,10 @@ on:
       - 'release/**'
       - 'feature/**'
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/SemicolonAmbulance/cardigantime/security/code-scanning/1](https://github.com/SemicolonAmbulance/cardigantime/security/code-scanning/1)

To fix the issue, add a `permissions` block to the workflow file. This block should specify the minimum permissions required for the workflow to function correctly. Based on the workflow's operations, the following permissions are appropriate:
- `contents: read` for accessing the repository contents.
- `id-token: write` for Codecov authentication (if required by Codecov).
- Additional permissions can be added if specific steps require them.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the `test` job to limit its scope.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
